### PR TITLE
switch openeo-api submodule href to HTTPS instead of git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 	branch = add-tests
 [submodule "assets/openeo-api"]
 	path = assets/openeo-api
-	url = git@github.com:Open-EO/openeo-api.git
+	url = https://github.com/Open-EO/openeo-api


### PR DESCRIPTION
Having `git@` reference make this really hard to install and use in CI 